### PR TITLE
Explain ouptut improvement

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -305,7 +305,6 @@ func GetOpenAPISpec(customResourceKind string) string {
 }
 
 func queryETCD(resourceKey string) string {
-	fmt.Println("Inside queryETCD")
 	cfg := client.Config{
 		Endpoints: []string{etcdServiceURL},
 		Transport: client.DefaultTransport,
@@ -328,7 +327,6 @@ func queryETCD(resourceKey string) string {
 		log.Printf("%q key has %q value\n", resp.Node.Key, resp.Node.Value)
 		return resp.Node.Value
 	}
-	fmt.Println("Exiting queryETCD")
 	return ""
 }
 


### PR DESCRIPTION
- Showing output of only the queried type
  (e.g.: /explain?kind=Postgres will show only top-level Postgres type's
   OpenAPISpec and not the entire OpenAPISpec)

- Added support for nested types in queries
  (e.g.: /explain?kind=Backup.BackupSpec.StorageProvider.S3StorageProvider)

Fixes: https://github.com/cloud-ark/kubeplus/issues/104