### PR TITLE
Namespace support

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -7,23 +7,23 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cloud-ark/kubediscovery/pkg/apiserver"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
-	"github.com/cloud-ark/kubediscovery/pkg/apiserver"
 )
 
 const defaultEtcdPathPrefix = "/registry/kubeplus.cloudark.io"
 
 type DiscoveryServerOptions struct {
 	RecommendedOptions *genericoptions.RecommendedOptions
-	StdOut                io.Writer
-	StdErr                io.Writer
+	StdOut             io.Writer
+	StdErr             io.Writer
 }
 
 func NewDiscoveryServerOptions(out, errOut io.Writer) *DiscoveryServerOptions {
 	o := &DiscoveryServerOptions{
-		RecommendedOptions: genericoptions.NewRecommendedOptions(defaultEtcdPathPrefix, 
+		RecommendedOptions: genericoptions.NewRecommendedOptions(defaultEtcdPathPrefix,
 			apiserver.Codecs.LegacyCodec(apiserver.SchemeGroupVersion)),
 		StdOut: out,
 		StdErr: errOut,

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -14,17 +14,19 @@ type composition struct {
 
 // Used for Final output
 type Composition struct {
-	Level    int
-	Kind     string
-	Name     string
-	Status   string
-	Children []Composition
+	Level     int
+	Kind      string
+	Name      string
+	Namespace string
+	Status    string
+	Children  []Composition
 }
 
 // Used to store information queried from the main API server
 type MetaDataAndOwnerReferences struct {
 	MetaDataName             string
 	Status                   string
+	Namespace                string
 	OwnerReferenceName       string
 	OwnerReferenceKind       string
 	OwnerReferenceAPIVersion string
@@ -42,6 +44,7 @@ type CompositionTreeNode struct {
 type Compositions struct {
 	Kind            string
 	Name            string
+	Namespace       string
 	Status          string
 	CompositionTree *[]CompositionTreeNode
 }


### PR DESCRIPTION
- Changed data structures to add a Namespace field
- ex: `kubectl get --raw "/apis/kubeplus.cloudark.io/v1/composition?kind=Pod&instance=*&namespace=ns1" | python -mjson.tool`
- Added method to get all namespaces
- Added query parameters, defaulting to 'default'
- Fixes: https://github.com/cloud-ark/kubediscovery/issues/16