### PR TITLE
Unmarshalling an invalid non-json string

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -179,12 +179,16 @@ func readKindCompositionFile() {
 		}
 	} else {
 		// Populate the Kind maps by querying CRDs from ETCD and querying KAPI for details of each CRD
-		crdListString := queryETCD("/operators")
-		if crdListString != "" {
+		crdListString, err := queryETCD("/operators")
+		if err == nil && crdListString != "" {
 			crdNameList := getCRDNames(crdListString)
 
 			for _, crdName := range crdNameList {
-				crdDetailsString := queryETCD("/" + crdName)
+				crdDetailsString, err := queryETCD("/" + crdName)
+				if err != nil {
+					fmt.Printf("Error: %s\n", err.Error())
+					return
+				}
 				kind, plural, endpoint, composition := getCRDDetails(crdDetailsString)
 
 				KindPluralMap[kind] = plural

--- a/pkg/discovery/operatordocs.go
+++ b/pkg/discovery/operatordocs.go
@@ -64,7 +64,7 @@ func GetOpenAPISpec(customResourceKind string) string {
 
 	// 1. Get ConfigMap Name by querying etcd at
 	resourceKey := "/" + customResourceKind + "-OpenAPISpecConfigMap"
-	configMapNameString := queryETCD(resourceKey)
+	configMapNameString, err := queryETCD(resourceKey)
 
 	var configMapName string
 	if err := json.Unmarshal([]byte(configMapNameString), &configMapName); err != nil {
@@ -94,7 +94,7 @@ func GetOpenAPISpec(customResourceKind string) string {
 	return openAPISpec
 }
 
-func queryETCD(resourceKey string) string {
+func queryETCD(resourceKey string) (string, error) {
 	cfg := client.Config{
 		Endpoints: []string{etcdServiceURL},
 		Transport: client.DefaultTransport,
@@ -107,8 +107,8 @@ func queryETCD(resourceKey string) string {
 
 	resp, err1 := kapi.Get(context.Background(), resourceKey, nil)
 	if err1 != nil {
-		return string(err1.Error())
+		return "", err1
 	} else {
-		return resp.Node.Value
+		return resp.Node.Value, nil
 	}
 }


### PR DESCRIPTION
- Fixes: https://github.com/cloud-ark/kubediscovery/issues/34
- Change queryETCD method signature to return err